### PR TITLE
fix: FIX randomly miss super-tabs on load

### DIFF
--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -37,6 +37,11 @@
   "LOGIN": {
     "USER_WELCOME": "Hello {{displayName}}"
   },
+  "HOME": {
+    "LIVE": "Live",
+    "ITEMS": "News",
+    "CONTACTS": "Contacts"
+  },
   "RESET_PASSWORD": {
     "LINK": "Forgot password?",
     "SUBMIT": "Reset",

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -73,6 +73,11 @@
   "LOGIN": {
     "USER_WELCOME": "Olá {{displayName}}"
   },
+  "HOME": {
+    "LIVE": "Ao Vivo",
+    "ITEMS": "Notícias",
+    "CONTACTS": "Contatos"
+  },
   "RESET_PASSWORD": {
     "LINK": "Esqueceu a senha?",
     "SUBMIT": "Gerar nova",

--- a/src/pages/home/home.html
+++ b/src/pages/home/home.html
@@ -25,8 +25,8 @@
 
 <ion-content no-bounce>
   <super-tabs [config]="{ sideMenu: 'left' }" *ngIf="!!(authData$ | async)">
-    <super-tab [root]="live" title="Ao Vivo"></super-tab>
-    <super-tab [root]="items" title="Notícias"></super-tab> 
-    <super-tab [root]="contacts" title="Contatos"></super-tab>
+    <super-tab [root]="live" title="{{'HOME.LIVE' | translate}}"></super-tab>
+    <super-tab [root]="items" title="{{'HOME.ITEMS' | translate}}"></super-tab>
+    <super-tab [root]="contacts" title="{{'HOME.CONTACTS' | translate}}"></super-tab>
   </super-tabs>
 </ion-content>


### PR DESCRIPTION
closes #116

# Checklist

- [x] My code follows the code style of this project. 
  - I've ran lint locally prior to submission.
- [ ] I successfully ran tests locally with my changes.
  - Keep mockup up-to-date for tests purpose.
- [x] I've followed the guidelines from Contributing document.
- [x] I've updated wiki doc when necessary (indicate which docs updated).
n/a
- [x] All actions are tracked on analytics (indicate which new actions).
n/a
- [x] All expressions are translated.
- [x] All commits Close related issue, using `Closes #ISSUE_ID`.

# Tests
Tests:
1. clear site data, remove www, run ionic serve
2. login with user with pt language
tabs showed and translated
3. update user language to en
tabs showed and translated
3. logout
4. login with user with en language
tabs showed and translated
5. logout
6. clear site data, remove www, run ionic serve
7.  login with user with en language
tabs showed and translated

I've removed my user from db 
1. login with new user without language preference
tabs showed and translated pt, default preferredLanguage = 'pt';
I've set on db an invalid lang 'es'
2. tabs showed and translated en (default language)

I've commented default language https://github.com/meumobi/ion-employee/blob/d3f10a309af26983c21a742dd6bd3bf1483181fe/src/app/app.component.ts#L82
And re-tested
1. clear site data, remove www, run ionic serve
2. login with user with pt language
tabs showed and translated
3. update user language to en
tabs showed and translated

