### PR TITLE
fix(authentication): verifiy length on change password

### DIFF
--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -53,6 +53,7 @@
     "SUBMIT": "Update",
     "PLACEHOLDER": "New password",
     "SUCCESS": "Password updated successfully",
-    "SUBTITLE": "For security reason you need to type here a new personal password."
+    "ERROR": "New password must contains at least six characters",
+    "SUBTITLE": "For security reason you need to type here a new personal password, containing at least six characters."
   }
 }

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -86,7 +86,8 @@
     "SUBMIT": "Alterar",
     "PLACEHOLDER": "Nova senha",
     "SUCCESS": "Senha alterada com sucesso",
-    "SUBTITLE": "Para sua melhor segurança é preciso alterar a sua senha para continuar."
+    "ERROR": "A nova senha deve conter pelo menos seis caracteres",
+    "SUBTITLE": "Para sua melhor segurança é preciso alterar a sua senha para continuar, contendo pelo menos seis carateres."
   },
   "CLIPBOARD_COPY": {
     "LINK": "Link copiado para a área de tranferência"

--- a/src/pages/login/login.ts
+++ b/src/pages/login/login.ts
@@ -195,6 +195,10 @@ export class LoginPage implements OnInit {
           }, {
             text: this.translateService.instant('CHANGE_PASSWORD.SUBMIT'),
             handler: data => {
+              if (data.newPassword.length < 6) {
+                this.meuToastService.present(this.translateService.instant('CHANGE_PASSWORD.ERROR'));
+                return false;
+              }
               this.authService.updatePassword(email, currentPassword, data.newPassword)
             .then(
               () => {


### PR DESCRIPTION
closes #324

# Checklist

- [x] My code follows the code style of this project. 
  - I've ran lint locally prior to submission.
- [ ] I successfully ran tests locally with my changes.
  - Keep mockup up-to-date for tests purpose.
- [x] I've followed the guidelines from Contributing document (indicate which docs updated).
- [ ] I've updated wiki doc when necessary (indicate which docs updated).
n/a
- [x] All actions are tracked on analytics (indicate which new actions).
n/a
- [x] All expressions are translated.
- [x] All commits Close related issue, using `Closes #ISSUE_ID`.

# Tests
1. Reset password
2. Login with temporary password 
3. Set a less than six chars password
4. Submit
Notify user of wrong password length
Stay on screen
5. Set a 6 or more length password
6. Submit
Reset password, redirect to home