### PR TITLE
fix(theme): apply custom them on navbar buttons ios

### DIFF
--- a/src/theme/theme.custom.scss
+++ b/src/theme/theme.custom.scss
@@ -18,7 +18,7 @@
   }
 
   ion-card-content h3,
-  ion-card-content h2 
+  ion-card-content h2
   {
     color: #{ion-color(primary, contrast)};
     color: var(--on-primary-color) !important;
@@ -27,6 +27,7 @@
 
   ion-item a, 
   .button-clear,
+  .bar-button-ios,
   form ion-item ion-label
   {
     color: color($colors, primary) !important;


### PR DESCRIPTION
closes #331

# Checklist

- [x] My code follows the code style of this project. 
  - I've ran lint locally prior to submission.
- [x] I successfully ran tests locally with my changes.
  - Keep mockup up-to-date for tests purpose.
- [x] I've followed the guidelines from Contributing document (indicate which docs updated).
- [x] I've updated wiki doc when necessary (indicate which docs updated).
n/a
- [x] All actions are tracked on analytics (indicate which new actions).
n/a
- [x] All expressions are translated.
n/a
- [x] All commits Close related issue, using `Closes #ISSUE_ID`.

# Tests
1. open app on safari
2. press cmd+ctrl+R
3. set Safari-iOS-iPhone
![image](https://user-images.githubusercontent.com/32454870/54539027-278b8600-4974-11e9-96ca-25c52f345aa3.png)
4. reload page
rendered as iphone
5. as admin set primary color on settings #729dac and save
icons with personalized primary color
6. clean primary color on settings and save 
icons with default primary color

on chrome (md) navbar icons must stay with md color as we can see here https://ionicframework.com/docs/v3/api/components/toolbar/Navbar/ 